### PR TITLE
change sed to match less

### DIFF
--- a/sbnMerlin.sh
+++ b/sbnMerlin.sh
@@ -1020,7 +1020,7 @@ dhcp_config() {
 				filelinecount=$(grep -c '# '"($script_name) Network Isolation Tool" "$pcfile")
 
 				if [ "$filelinecount" -gt 1 ] || [ "$filelinecount" -gt 0 ]; then
-					sed -i -e '/'"$bri_name"'/,/# ('"$script_name"')/d' "$pcfile"
+					sed -i -e '/'"$bri_name"'.*('"$script_name"')/d' "$pcfile"
 				fi
 
 				# Gathering values from config


### PR DESCRIPTION
If you have two bridges, it seems that the `sed` command deletes one line too many - notice the `pc_append "interface=br8"` line below. At least for me it did; it caused an interesting bug where exactly one in every two reloads would miss the interface line. Changing the sed pattern seems to fix it.

```
arne@asus:/tmp/home/root# /jffs/scripts/sbnMerlin rc && head /jffs/scripts/dnsmasq.postconf -n 7
#!/bin/sh
CONFIG=$1

. /usr/sbin/helper.sh

pc_append "interface=br8" "$CONFIG" # (sbnMerlin) Network Isolation Tool
pc_append "dhcp-range=br8,10.22.2.100,10.22.2.200,255.255.255.0,86400s" "$CONFIG" # (sbnMerlin) Network Isolation Tool

arne@asus:/tmp/home/root# /jffs/scripts/sbnMerlin rc && head /jffs/scripts/dnsmasq.postconf -n 7
#!/bin/sh
CONFIG=$1

. /usr/sbin/helper.sh

pc_append "dhcp-range=br8,10.22.2.100,10.22.2.200,255.255.255.0,86400s" "$CONFIG" # (sbnMerlin) Network Isolation Tool
pc_append "dhcp-option=br8,3,10.29.2.1" "$CONFIG" # (sbnMerlin) Network Isolation Tool
```