### PR TITLE
v1.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/96872a441a714fc6b88d6e58609461d1)](https://app.codacy.com/gh/janico82/sbnMerlin/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 ![Shellcheck](https://github.com/janico82/sbnMerlin/actions/workflows/shellcheck.yml/badge.svg)
 
-## v1.2.0
-### Updated on 2024-04-18
+## v1.2.1
+### Updated on 2024-04-19
 ## About
 Feature expansion of Wireless guest networks (wl0.2, wl0.3, wl1.2 and wl1.3) on AsusWRT-Merlin, that allows to:
 *   Automatic creation of ethernet bridge instances, based on active guest wireless networks and settings.

--- a/README.md
+++ b/README.md
@@ -2,21 +2,22 @@
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/96872a441a714fc6b88d6e58609461d1)](https://app.codacy.com/gh/janico82/sbnMerlin/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 ![Shellcheck](https://github.com/janico82/sbnMerlin/actions/workflows/shellcheck.yml/badge.svg)
 
-## v1.1.1
-### Updated on 2024-03-10
+## v1.2.0
+### Updated on 2024-04-18
 ## About
 Feature expansion of Wireless guest networks (wl0.2, wl0.3, wl1.2 and wl1.3) on AsusWRT-Merlin, that allows to:
 *   Automatic creation of ethernet bridge instances, based on active guest wireless networks and settings.
 *   Manage wireless interface isolation, for the interfaces mapped in the bridge instance.
 *   Map other ethernet interfaces to the bridge instance.
 *   Manage Internet and one-way access for the bridge instance.
-*   Custom DHCP settings for the bridge instance.
+*   Custom DHCP(ip range, default gateway and static list) and DNS settings for the bridge instance.
 *   Custom ethernet bridge and packet filtering rules for the bridge instance.
 
 For ethernet bridge instances created by AsusWRT-Merlin (br1 and br2), that allows to:
 *   Manage wireless interface isolation, for the interfaces mapped in the bridge instance.
 *   Map other ethernet interfaces to the bridge instance.
 *   Manage Internet and one-way access for the bridge instance.
+*   Custom DHCP(static list) and DNS settings for the bridge instance.
 *   Custom ethernet bridge and packet filtering rules for the bridge instance.
 
 Running configuration example:

--- a/README.md
+++ b/README.md
@@ -160,6 +160,12 @@ Start IP address of the bridge DHCP pool. Example: br8_dhcp_start="192.168.108.2
 #### {bridge}_dhcp_end
 End IP address of the bridge DHCP pool. Example: br8_dhcp_end="192.168.108.254"
 
+#### {bridge}_dns1_x
+Bridge-specific DNS server entry. Example: br8_dns1_x="8.8.8.8"
+
+#### {bridge}_dns2_x
+Bridge-specific DNS server entry. Example: br8_dns2_x="8.8.8.8
+
 #### {bridge}_staticlist
 IP address reservation of the bridge. Example: br8_staticlist=\<ab:cd:ef:01:23:45\>192.168.108.10\>8.8.8.8\>HOMEPC\<ab:cd:ef:01:23:46\>192.168.108.11\>\>Xbox\<ab:cd:ef:01:23:47\>192.168.168.108.12\>\>
 

--- a/sbnMerlin.conf
+++ b/sbnMerlin.conf
@@ -12,18 +12,17 @@
 #############################################################
 
 # RT-AX86U physical port to interface map:
-# eth0  eth1  eth2  eth3  eth4  eth5
-# WAN   LAN4  LAN3  LAN2  LAN1  LAN5(2.5G)
-# 
-# 2.4 GHz Radio
-# eth6 Guest Networks: wl0.1 wl0.2 wl0.3
-#
-# 5 GHz Radio
-# eth7 Guest Networks: wl1.1 wl1.2 wl1.3
+# eth0  eth1  eth2  eth3  eth4  eth5  eth6    eth7
+# WAN   LAN4  LAN3  LAN2  LAN1  LAN5  Wrls    Wrls
+#                                   (2.4GHz) (5GHz)
+# 2.4GHz Guest Networks: wl0.1 wl0.2 wl0.3
+# 5GHz Guest Networks:   wl1.1 wl1.2 wl1.3
 
 #### Settings for Bridge 1 ####
 br1_enabled=0
 br1_ifnames=""
+br1_dns1_x=""
+br1_dns2_x=""
 br1_staticlist=""
 br1_ap_isolate=1
 br1_allow_internet=1
@@ -33,6 +32,8 @@ br1_allow_routeraccess=0
 #### Settings for Bridge 2 ####
 br2_enabled=0
 br2_ifnames=""
+br2_dns1_x=""
+br2_dns2_x=""
 br2_staticlist=""
 br2_ap_isolate=1
 br2_allow_internet=1
@@ -46,6 +47,8 @@ br3_ipaddr="192.168.103.1"
 br3_netmask="255.255.255.0"
 br3_dhcp_start="192.168.103.2"
 br3_dhcp_end="192.168.103.254"
+br3_dns1_x=""
+br3_dns2_x=""
 br3_staticlist=""
 br3_ap_isolate=1
 br3_allow_internet=0
@@ -59,6 +62,8 @@ br4_ipaddr="192.168.104.1"
 br4_netmask="255.255.255.0"
 br4_dhcp_start="192.168.104.2"
 br4_dhcp_end="192.168.104.254"
+br4_dns1_x=""
+br4_dns2_x=""
 br4_staticlist=""
 br4_ap_isolate=1
 br4_allow_internet=0
@@ -72,6 +77,8 @@ br5_ipaddr="192.168.105.1"
 br5_netmask="255.255.255.0"
 br5_dhcp_start="192.168.105.2"
 br5_dhcp_end="192.168.105.254"
+br5_dns1_x=""
+br5_dns2_x=""
 br5_staticlist=""
 br5_ap_isolate=1
 br5_allow_internet=0
@@ -85,6 +92,8 @@ br6_ipaddr="192.168.106.1"
 br6_netmask="255.255.255.0"
 br6_dhcp_start="192.168.106.2"
 br6_dhcp_end="192.168.106.254"
+br6_dns1_x=""
+br6_dns2_x=""
 br6_staticlist=""
 br6_ap_isolate=1
 br6_allow_internet=0
@@ -101,6 +110,8 @@ br8_ipaddr="192.168.108.1"
 br8_netmask="255.255.255.0"
 br8_dhcp_start="192.168.108.2"
 br8_dhcp_end="192.168.108.254"
+br8_dns1_x=""
+br8_dns2_x=""
 br8_staticlist=""
 br8_ap_isolate=1
 br8_allow_internet=0
@@ -114,6 +125,8 @@ br9_ipaddr="192.168.109.1"
 br9_netmask="255.255.255.0"
 br9_dhcp_start="192.168.109.2"
 br9_dhcp_end="192.168.109.254"
+br9_dns1_x=""
+br9_dns2_x=""
 br9_staticlist=""
 br9_ap_isolate=1
 br9_allow_internet=0

--- a/sbnMerlin.sh
+++ b/sbnMerlin.sh
@@ -14,7 +14,7 @@
 ##           and to @jackyaz for the YazFi script          ##
 ##         to @RMerlin for AsusWRT-Merlin firmware.        ##
 #############################################################
-# Last Modified: janico82 [2024-Apr-18].
+# Last Modified: janico82 [2024-Apr-19].
 #--------------------------------------------------
 
 # Shellcheck directives #
@@ -36,7 +36,7 @@ readonly script_xdir="/jffs/scripts"
 readonly script_diag="/tmp/$script_name"
 readonly script_config="$script_dir/$script_name.conf"
 readonly script_md5="$script_dir/$script_name.md5"
-readonly script_version="1.2.0"
+readonly script_version="1.2.1"
 readonly script_branch="master"
 readonly script_repo="https://janico82.gateway.scarf.sh/asuswrt-merlin/$script_name/$script_branch"
 
@@ -1050,7 +1050,7 @@ dhcp_config() {
 				filelinecount=$(grep -c '# '"($script_name) Network Isolation Tool" "$pcfile")
 
 				if [ "$filelinecount" -gt 1 ] || [ "$filelinecount" -gt 0 ]; then
-					sed -i -e '/'"$bri_name"'/,/# ('"$script_name"')/d' "$pcfile"
+					sed -i -e '/'"$bri_name"'.*# ('"$script_name"')/d' "$pcfile" ## Solution suggested by @arner ##
 				fi
 
 				# Gathering values from config
@@ -1129,7 +1129,7 @@ dhcp_config() {
 				filelinecount=$(grep -c '# '"($script_name) Network Isolation Tool" "$pcfile")
 
 				if [ "$filelinecount" -gt 1 ] || [ "$filelinecount" -gt 0 ]; then
-					sed -i -e '/'"$bri_name"'/,/# ('"$script_name"')/d' "$pcfile"
+					sed -i -e '/'"$bri_name"'.*# ('"$script_name"')/d' "$pcfile" ## Solution suggested by @arner ##
 				fi
 
 				# Gathering values from config
@@ -1177,7 +1177,7 @@ dhcp_config() {
 				filelinecount=$(grep -c "$script_name" "$pcfile")
 				
 				if [ "$filelinecount" -gt 0 ]; then
-					sed -i -e '/'"$bri_name"'/,/# ('"$script_name"')/d' "$pcfile"
+					sed -i -e '/'"$bri_name"'.*# ('"$script_name"')/d' "$pcfile" ## Solution suggested by @arner ##
 
 					# Setup nvram values for bridge.
 					nvram unset "${bri_name}_dhcp_start"
@@ -1198,7 +1198,7 @@ dhcp_config() {
 				filelinecount=$(grep -c "$script_name" "$pcfile")
 				
 				if [ "$filelinecount" -gt 0 ]; then
-					sed -i -e '/'"$bri_name"'/,/# ('"$script_name"')/d' "$pcfile"
+					sed -i -e '/'"$bri_name"'.*# ('"$script_name"')/d' "$pcfile" ## Solution suggested by @arner ##
 
 					loggerEx "Hosts settings for bridge($bri_name) removed."
 

--- a/sbnMerlin.sh
+++ b/sbnMerlin.sh
@@ -1862,7 +1862,7 @@ configEx() {
 	fi
 	if bridge_enabled br8 ; then
 	
-		if ! wlif_enabled wl0.2 || wlif_lanaccess wl0.2 || ! wlif_enabled wl1.2 || wlif_lanaccess wl1.2 || [ "$(getconf_bri_enabled br8 sc)" = $env_disable ]; then
+		if ! wlif_enabled wl0.2 || wlif_lanaccess wl0.2 || ! wlif_enabled wl1.2 || wlif_lanaccess wl1.2 || ! compare_ssid wl0.2 wl1.2 || [ "$(getconf_bri_enabled br8 sc)" = $env_disable ]; then
 
 			firewall_config delete br8
 			bridge_ifname_config delete br8
@@ -1890,7 +1890,7 @@ configEx() {
 	fi
 	if bridge_enabled br9 ; then
 	
-		if ! wlif_enabled wl0.3 || wlif_lanaccess wl0.3 || ! wlif_enabled wl1.3 || wlif_lanaccess wl1.3 || [ "$(getconf_bri_enabled br9 sc)" = $env_disable ]; then
+		if ! wlif_enabled wl0.3 || wlif_lanaccess wl0.3 || ! wlif_enabled wl1.3 || wlif_lanaccess wl1.3 || ! compare_ssid wl0.3 wl1.3 || [ "$(getconf_bri_enabled br9 sc)" = $env_disable ]; then
 
 			firewall_config delete br9
 			bridge_ifname_config delete br9

--- a/sbnMerlin.sh
+++ b/sbnMerlin.sh
@@ -14,7 +14,7 @@
 ##           and to @jackyaz for the YazFi script          ##
 ##         to @RMerlin for AsusWRT-Merlin firmware.        ##
 #############################################################
-# Last Modified: janico82 [2024-Mar-10].
+# Last Modified: janico82 [2024-Apr-18].
 #--------------------------------------------------
 
 # Shellcheck directives #
@@ -36,7 +36,7 @@ readonly script_xdir="/jffs/scripts"
 readonly script_diag="/tmp/$script_name"
 readonly script_config="$script_dir/$script_name.conf"
 readonly script_md5="$script_dir/$script_name.md5"
-readonly script_version="1.1.1"
+readonly script_version="1.2.0"
 readonly script_branch="master"
 readonly script_repo="https://janico82.gateway.scarf.sh/asuswrt-merlin/$script_name/$script_branch"
 
@@ -50,6 +50,7 @@ readonly env_restart=1
 readonly env_no_restart=0
 readonly env_enable=1
 readonly env_disable=0
+readonly env_no_dns="0.0.0.0"
 # Script regex variables
 readonly env_regex_version="[0-9]{1,2}([.][0-9]{1,2})([.][0-9]{1,2})"
 readonly env_regex_binary="[01]"
@@ -362,6 +363,35 @@ getconf_bri_ap_isolate() {
 	fi
 
 	echo $bri_ap_isolate
+}
+
+getconf_bri_dns1() {
+	echo "$(getconf_bri_dns $1 1 $2)"
+}
+
+getconf_bri_dns2() {
+	echo "$(getconf_bri_dns $1 2 $2)"
+}
+
+getconf_bri_dns() {
+
+	# Always get config settings from nvram.
+	bri_dns="$(nvram get "${1}_dns${2}_x")"
+
+	# Get config settings from file, if exists nvram settings does not exists, or if the "sc" flag is ative.
+	if { { [ "$#" -eq 2 ] && [ -z "$bri_dns" ]; } || { [ "$#" -eq 3 ] && [ "$3" = "sc" ]; }; } && [ -f $script_config ]; then
+
+		. $script_config
+		bri_dns="$(eval echo '$'"${1}_dns${2}_x")"
+	fi
+
+	# If the settings values aren't valid, get defaults.
+	if [ -z $bri_dns ] || ! validate_ipaddr "$bri_dns" ; then
+		bri_dns=$env_no_dns
+		loggerEx "Error: Invalid dns configuration gathered, using defaults($bri_dns)."
+	fi
+
+	echo $bri_dns
 }
 
 getconf_bri_enabled() {
@@ -1026,6 +1056,8 @@ dhcp_config() {
 				# Gathering values from config
 				bri_ipaddr=$(getconf_bri_ipaddr "$bri_name")
 				bri_netmask=$(getconf_bri_netmask "$bri_name")
+				bri_dns1=$(getconf_bri_dns1 "$bri_name")
+				bri_dns2=$(getconf_bri_dns2 "$bri_name")
 				bri_staticlist=$(getconf_bri_staticlist "$bri_name")
 
 				loggerEx "Applying DHCPv4 settings for bridge($bri_name)."
@@ -1051,6 +1083,11 @@ dhcp_config() {
 					nvram set "${bri_name}_dhcp_end"="$bri_dhcp_end"
 				fi
 
+				# DHCPv4 default dns servers
+				if [ "$bri_dns1" != "$env_no_dns" ] || [ "$bri_dns2" != "$env_no_dns" ]; then
+					echo 'pc_append "dhcp-option='"$bri_name"',6,'"$bri_dns1"','"$bri_dns2"'" "$CONFIG" # ('"$script_name"') Network Isolation Tool' >> "$pcfile"
+				fi
+
 				# DHCPv4 ip address reservation
 				for static in $(echo "${bri_staticlist#<}" | tr '<' ' '); do
 
@@ -1071,12 +1108,16 @@ dhcp_config() {
 				done
 
 				# Setup nvram values for bridge.
+				nvram set "${bri_name}_dns1_x"="$bri_dns1"
+				nvram set "${bri_name}_dns2_x"="$bri_dns2"
 				nvram set "${bri_name}_staticlist"="$bri_staticlist"
 				nvram commit
 
 				loggerEx "DHCPv4 settings for bridge($bri_name) completed."
 
 				unset bri_staticlist
+				unset bri_dns2
+				unset bri_dns1
 				unset bri_dhcp_end
 				unset bri_dhcp_start
 
@@ -1139,8 +1180,10 @@ dhcp_config() {
 					sed -i -e '/'"$bri_name"'/,/# ('"$script_name"')/d' "$pcfile"
 
 					# Setup nvram values for bridge.
-					nvram unset "${bri_name}_dhcp_end"
 					nvram unset "${bri_name}_dhcp_start"
+					nvram unset "${bri_name}_dhcp_end"
+					nvram unset "${bri_name}_dns1_x"
+					nvram unset "${bri_name}_dns2_x"
 					nvram unset "${bri_name}_staticlist"
 					nvram commit
 
@@ -2149,6 +2192,16 @@ script_check_config() {
 				nvram set "${bri_name}_dhcp_start"="$(getconf_bri_dhcp_start "$bri_name" sc)"
 				nvram set "${bri_name}_dhcp_end"="$(getconf_bri_dhcp_end "$bri_name" sc)"
 				nvram set "${bri_name}_staticlist"="$(getconf_bri_staticlist "$bri_name" sc)"
+
+				dhcp_config create "$bri_name"
+			fi
+
+			if [ "$(getconf_bri_dns1 "$bri_name" nv)" != "$(getconf_bri_dns1 "$bri_name" sc)" ] || [ "$(getconf_bri_dns2 "$bri_name" nv)" != "$(getconf_bri_dns2 "$bri_name" sc)" ]; then
+				loggerEx cli "Change detected on bridge($bri_name) DNS settings. Applying changes."
+
+				# Setting values in nvram to run properly.
+				nvram set "${bri_name}_dns1_x"="$(getconf_bri_dns1 "$bri_name" sc)"
+				nvram set "${bri_name}_dns2_x"="$(getconf_bri_dns2 "$bri_name" sc)"
 
 				dhcp_config create "$bri_name"
 			fi


### PR DESCRIPTION
New feature: ability to configure bridge-specific DNS servers.
Bugfix: dnsmasq and hosts files miss configuration with multiple bridges caused by wrong sed pattern.
Bugfix: problem with the removal of bridge(br9) when the SSID of wl0.3 and wl1.3 are changed to a different name.