### PR TITLE
Bugfix: match logdrop/logaccept targets in FORWARD rule positioning

### DIFF
--- a/sbnMerlin.sh
+++ b/sbnMerlin.sh
@@ -1665,7 +1665,7 @@ firewall_config() {
 		if [ $bri_allow_internet -eq $env_enable ]; then
 
 			for wan_ifname in $wan_ifnames; do # Find rule position in the FORWARD chain before the WAN ifname.
-				rp="$(iptables --line-numbers -vL FORWARD | grep -E -m 1 '(DROP|ACCEPT).*((!br0|br[1-9])\s+'$wan_ifname')\s+anywhere' | awk '{print $1}')"
+				rp="$(iptables --line-numbers -vL FORWARD | grep -E -m 1 '(DROP|ACCEPT|logdrop|logaccept).*((!br0|br[1-9])\s+'$wan_ifname')\s+anywhere' | awk '{print $1}')"
 				
 				iptables -I FORWARD "$rp" -i "$bri_name" -o "$wan_ifname" -j ACCEPT >/dev/null 2>&1
 			done
@@ -1673,7 +1673,7 @@ firewall_config() {
 
 		# Forbid packets from bridge to be forwarded to other interfaces.
 		for wan_ifname in $wan_ifnames; do # Find rule position in the FORWARD chain before the WAN ifname.
-			rp="$(iptables --line-numbers -vL FORWARD | grep -E -m 1 'WGNPControls|((DROP|ACCEPT)\s+all\s+--\s+(!br0|br[1-9])\s+'$wan_ifname')\s+anywhere' | awk '{print $1}')"
+			rp="$(iptables --line-numbers -vL FORWARD | grep -E -m 1 'WGNPControls|((DROP|ACCEPT|logdrop|logaccept)\s+all\s+--\s+(!br0|br[1-9])\s+'$wan_ifname')\s+anywhere' | awk '{print $1}')"
 			
 			iptables -I FORWARD "$rp" -i "$bri_name" -j WGNPControls >/dev/null 2>&1
 		done


### PR DESCRIPTION
### Problem

On some Asuswrt-Merlin configurations, the FORWARD chain uses `logdrop` and `logaccept` targets instead of plain `DROP` and `ACCEPT`. This causes the `firewall_config()` function to fail silently when inserting rules for `br*_allow_internet=1`.

**Root cause:** The regex pattern `(DROP|ACCEPT)` doesn't match `logdrop`, so the rule position `$rp` evaluates to empty, and the subsequent `iptables -I FORWARD "" ...` command fails silently.

**Symptom:** Devices on isolated bridges (e.g., br4) lose internet access after router reboot, despite having `br4_allow_internet=1` configured correctly.

### Example

Before fix, with this FORWARD chain:
```
19   78916   15M logdrop    all  --  !br0   eth0    anywhere             anywhere
```

The regex `(DROP|ACCEPT).*((!br0|br[1-9])\s+eth0)\s+anywhere` returns nothing because `logdrop` doesn't match.

### Solution

Extend the regex patterns in `firewall_config()` to include `logdrop` and `logaccept` targets:
```diff
- '(DROP|ACCEPT).*((!br0|br[1-9])\s+'$wan_ifname')\s+anywhere'
+ '(DROP|ACCEPT|logdrop|logaccept).*((!br0|br[1-9])\s+'$wan_ifname')\s+anywhere'
```

### Testing

Tested on:
- ASUS RT-AX88U running Asuswrt-Merlin 3004.388.11
- Bridge br4 with `br4_allow_internet=1`
- Confirmed rule insertion works correctly after fix
